### PR TITLE
Security fixes

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.10</version>
+        <version>2.7.18</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
-            <version>1.2.5.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/BruteForceProtectionFilter.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/BruteForceProtectionFilter.java
@@ -1,7 +1,6 @@
 package uk.ac.ebi.eva.submission.controller.authentication;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -10,7 +9,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-@Component
 public class BruteForceProtectionFilter extends OncePerRequestFilter {
 
     private final BruteForceProtectionService bruteForceService;

--- a/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/BruteForceProtectionFilter.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/BruteForceProtectionFilter.java
@@ -1,0 +1,39 @@
+package uk.ac.ebi.eva.submission.controller.authentication;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class BruteForceProtectionFilter extends OncePerRequestFilter {
+
+    private final BruteForceProtectionService bruteForceService;
+
+    public BruteForceProtectionFilter(BruteForceProtectionService bruteForceService) {
+        this.bruteForceService = bruteForceService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        if (req.getRequestURI().contains("/v1/admin/")) {
+            String ip = req.getRemoteAddr();
+            if (bruteForceService.isBlocked(ip)) {
+                res.sendError(HttpStatus.TOO_MANY_REQUESTS.value(), "Too many failed login attempts. Try again later.");
+                return;
+            }
+            chain.doFilter(req, res);
+            if (res.getStatus() == HttpStatus.OK.value()) {
+                bruteForceService.onAuthenticationSuccess(ip);
+            }
+        } else {
+            chain.doFilter(req, res);
+        }
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/BruteForceProtectionService.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/BruteForceProtectionService.java
@@ -1,0 +1,47 @@
+package uk.ac.ebi.eva.submission.controller.authentication;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class BruteForceProtectionService implements ApplicationListener<AbstractAuthenticationFailureEvent> {
+
+    private static final int MAX_ATTEMPTS = 10;
+    private static final long LOCKOUT_DURATION_MS = 15 * 60_000L;
+
+    private final Map<String, AtomicInteger> attempts = new ConcurrentHashMap<>();
+    private final Map<String, Long> lockouts = new ConcurrentHashMap<>();
+
+    @Override
+    public void onApplicationEvent(AbstractAuthenticationFailureEvent event) {
+        if (event.getAuthentication().getDetails() instanceof WebAuthenticationDetails) {
+            String ip = ((WebAuthenticationDetails) event.getAuthentication().getDetails()).getRemoteAddress();
+            int count = attempts.computeIfAbsent(ip, k -> new AtomicInteger()).incrementAndGet();
+            if (count >= MAX_ATTEMPTS) {
+                lockouts.put(ip, System.currentTimeMillis() + LOCKOUT_DURATION_MS);
+            }
+        }
+    }
+
+    public void onAuthenticationSuccess(String ip) {
+        attempts.remove(ip);
+        lockouts.remove(ip);
+    }
+
+    public boolean isBlocked(String ip) {
+        Long until = lockouts.get(ip);
+        if (until == null) return false;
+        if (System.currentTimeMillis() > until) {
+            lockouts.remove(ip);
+            attempts.remove(ip);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/CustomBasicAuthenticationEntryPoint.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/CustomBasicAuthenticationEntryPoint.java
@@ -36,7 +36,7 @@ public class CustomBasicAuthenticationEntryPoint extends BasicAuthenticationEntr
         response.addHeader("WWW-Authenticate", "Basic realm=" + getRealmName() + "");
 
         PrintWriter writer = response.getWriter();
-        writer.println("HTTP Status 401 : " + authException.getMessage());
+        writer.println("HTTP Status 401 : Authentication Failed");
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/SecurityConfiguration.java
@@ -18,12 +18,16 @@ package uk.ac.ebi.eva.submission.controller.authentication;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -35,6 +39,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final CustomBasicAuthenticationEntryPoint customBasicAuthenticationEntryPoint;
 
+    private final BruteForceProtectionFilter bruteForceProtectionFilter;
+
     @Value("${controller.auth.admin.username}")
     private String USERNAME_ADMIN;
 
@@ -42,13 +48,23 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private String PASSWORD_ADMIN;
 
     @Autowired
-    public SecurityConfiguration(CustomBasicAuthenticationEntryPoint customBasicAuthenticationEntryPoint) {
+    public SecurityConfiguration(CustomBasicAuthenticationEntryPoint customBasicAuthenticationEntryPoint,
+                                  BruteForceProtectionFilter bruteForceProtectionFilter) {
         this.customBasicAuthenticationEntryPoint = customBasicAuthenticationEntryPoint;
+        this.bruteForceProtectionFilter = bruteForceProtectionFilter;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Autowired
     public void configureGlobalSecurity(AuthenticationManagerBuilder auth) throws Exception {
-        auth.inMemoryAuthentication().withUser(USERNAME_ADMIN).password("{noop}" + PASSWORD_ADMIN).roles(ROLE_ADMIN);
+        auth.inMemoryAuthentication()
+                .withUser(USERNAME_ADMIN)
+                .password(passwordEncoder().encode(PASSWORD_ADMIN))
+                .roles(ROLE_ADMIN);
     }
 
     @Override
@@ -56,9 +72,13 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         http.csrf().disable()
                 .authorizeRequests()
                 .antMatchers("/v1/submission/**").permitAll()
+                .antMatchers("/v1/call-home/**").permitAll()
+                .antMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/v3/api-docs").permitAll()
                 .antMatchers("/v1/admin/**").hasRole(ROLE_ADMIN)
+                .anyRequest().authenticated()
                 .and().httpBasic().realmName(REALM)
                 .authenticationEntryPoint(customBasicAuthenticationEntryPoint)
-                .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and().addFilterBefore(bruteForceProtectionFilter, BasicAuthenticationFilter.class);
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/SecurityConfiguration.java
@@ -69,6 +69,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        // CSRF disabled intentionally — stateless REST API uses Basic Auth with no session cookies, so CSRF is not applicable
         http.csrf().disable()
                 .authorizeRequests()
                 .antMatchers("/v1/submission/**").permitAll()

--- a/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/controller/authentication/SecurityConfiguration.java
@@ -39,7 +39,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final CustomBasicAuthenticationEntryPoint customBasicAuthenticationEntryPoint;
 
-    private final BruteForceProtectionFilter bruteForceProtectionFilter;
+    private final BruteForceProtectionService bruteForceProtectionService;
 
     @Value("${controller.auth.admin.username}")
     private String USERNAME_ADMIN;
@@ -49,9 +49,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired
     public SecurityConfiguration(CustomBasicAuthenticationEntryPoint customBasicAuthenticationEntryPoint,
-                                  BruteForceProtectionFilter bruteForceProtectionFilter) {
+                                  BruteForceProtectionService bruteForceProtectionService) {
         this.customBasicAuthenticationEntryPoint = customBasicAuthenticationEntryPoint;
-        this.bruteForceProtectionFilter = bruteForceProtectionFilter;
+        this.bruteForceProtectionService = bruteForceProtectionService;
     }
 
     @Bean
@@ -59,8 +59,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         return new BCryptPasswordEncoder();
     }
 
-    @Autowired
-    public void configureGlobalSecurity(AuthenticationManagerBuilder auth) throws Exception {
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth.inMemoryAuthentication()
                 .withUser(USERNAME_ADMIN)
                 .password(passwordEncoder().encode(PASSWORD_ADMIN))
@@ -79,6 +79,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .and().httpBasic().realmName(REALM)
                 .authenticationEntryPoint(customBasicAuthenticationEntryPoint)
                 .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and().addFilterBefore(bruteForceProtectionFilter, BasicAuthenticationFilter.class);
+                .and().addFilterBefore(new BruteForceProtectionFilter(bruteForceProtectionService), BasicAuthenticationFilter.class);
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/submission/service/SubmissionService.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/service/SubmissionService.java
@@ -453,5 +453,4 @@ public class SubmissionService {
         return submissionDetailsRepository.findBySubmissionId(submissionId);
     }
 
-
 }

--- a/src/main/java/uk/ac/ebi/eva/submission/util/BioSamplesDownloader.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/util/BioSamplesDownloader.java
@@ -5,11 +5,14 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.regex.Pattern;
+
 @Component
 public class BioSamplesDownloader {
     private final RestTemplate restTemplate;
 
     private static final String BIO_SAMPLES_BASE_URL = "https://www.ebi.ac.uk/biosamples/samples/";
+    private static final Pattern BIOSAMPLES_ACCESSION = Pattern.compile("^SAM[END][AG]?[0-9]+$");
 
     public BioSamplesDownloader(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
@@ -17,6 +20,9 @@ public class BioSamplesDownloader {
 
     @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 2000, multiplier = 2))
     public String downloadSampleFromBioSamples(String accession) {
+        if (!BIOSAMPLES_ACCESSION.matcher(accession).matches()) {
+            throw new IllegalArgumentException("Invalid BioSamples accession format: " + accession);
+        }
         return restTemplate.getForObject(BIO_SAMPLES_BASE_URL + accession + ".json", String.class);
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/submission/util/EnaDownloader.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/util/EnaDownloader.java
@@ -11,12 +11,14 @@ import org.xml.sax.InputSource;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.StringReader;
+import java.util.regex.Pattern;
 
 @Component
 public class EnaDownloader {
     private final RestTemplate restTemplate;
 
     private static final String ENA_BASE_URL = "https://www.ebi.ac.uk/ena/browser/api/xml/";
+    private static final Pattern ENA_ACCESSION = Pattern.compile("^[A-Z]{1,6}[0-9]{1,9}$");
 
     public EnaDownloader(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
@@ -24,8 +26,16 @@ public class EnaDownloader {
 
     @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 2000, multiplier = 2))
     public Document downloadXmlFromEna(String projectAccession) throws Exception {
+        if (!ENA_ACCESSION.matcher(projectAccession).matches()) {
+            throw new IllegalArgumentException("Invalid ENA accession format: " + projectAccession);
+        }
         String responseBody = restTemplate.getForObject(ENA_BASE_URL + projectAccession, String.class);
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
         DocumentBuilder builder = factory.newDocumentBuilder();
         return builder.parse(new InputSource(new StringReader(responseBody)));
     }

--- a/src/main/java/uk/ac/ebi/eva/submission/util/HTMLHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/util/HTMLHelper.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.eva.submission.util;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -8,6 +10,10 @@ public class HTMLHelper {
 
     public HTMLHelper() {
         htmlBuilder = new StringBuilder();
+    }
+
+    private static String esc(String s) {
+        return s == null ? "" : StringEscapeUtils.escapeHtml4(s);
     }
 
     public HTMLHelper addLineBreak() {
@@ -21,42 +27,42 @@ public class HTMLHelper {
     }
 
     public HTMLHelper addText(String text) {
-        htmlBuilder.append(text);
+        htmlBuilder.append(esc(text));
         return this;
     }
 
     public HTMLHelper addTextWithSize(String text, int size) {
-        htmlBuilder.append("<span style=\"font-size:" + size + "px;\">" + text + "</span>");
+        htmlBuilder.append("<span style=\"font-size:" + size + "px;\">" + esc(text) + "</span>");
         return this;
     }
 
     public HTMLHelper addTextWithColor(String text, String color) {
-        htmlBuilder.append("<span style=\"color:" + color + ";\">" + text + "</span>");
+        htmlBuilder.append("<span style=\"color:" + esc(color) + ";\">" + esc(text) + "</span>");
         return this;
     }
 
     public HTMLHelper addBoldText(String text) {
-        htmlBuilder.append("<b>" + text + "</b>");
+        htmlBuilder.append("<b>" + esc(text) + "</b>");
         return this;
     }
 
     public HTMLHelper addLink(String url, String text) {
-        htmlBuilder.append("<a href=\"" + url + "\">" + text + "</a>");
+        htmlBuilder.append("<a href=\"" + esc(url) + "\">" + esc(text) + "</a>");
         return this;
     }
 
     public HTMLHelper addEmailLink(String email, String text) {
-        htmlBuilder.append("<a href=\"mailto:" + email + "\">" + text + "</a>");
+        htmlBuilder.append("<a href=\"mailto:" + esc(email) + "\">" + esc(text) + "</a>");
         return this;
     }
 
     public HTMLHelper addEmailLinkWithSize(String email, String text, int size) {
-        htmlBuilder.append("<span style=\"font-size:" + size + "px;\"> <a href=\"mailto:" + email + "\">" + text + "</a> </span>");
+        htmlBuilder.append("<span style=\"font-size:" + size + "px;\"> <a href=\"mailto:" + esc(email) + "\">" + esc(text) + "</a> </span>");
         return this;
     }
 
     public HTMLHelper addBoldTextWithColor(String text, String color) {
-        htmlBuilder.append("<b><span style=\"color:" + color + ";\">" + text + "</span></b>");
+        htmlBuilder.append("<b><span style=\"color:" + esc(color) + ";\">" + esc(text) + "</span></b>");
         return this;
     }
 

--- a/src/main/java/uk/ac/ebi/eva/submission/util/HTMLHelper.java
+++ b/src/main/java/uk/ac/ebi/eva/submission/util/HTMLHelper.java
@@ -47,17 +47,17 @@ public class HTMLHelper {
     }
 
     public HTMLHelper addLink(String url, String text) {
-        htmlBuilder.append("<a href=\"" + esc(url) + "\">" + esc(text) + "</a>");
+        htmlBuilder.append("<a href=\"" + url + "\">" + esc(text) + "</a>");
         return this;
     }
 
     public HTMLHelper addEmailLink(String email, String text) {
-        htmlBuilder.append("<a href=\"mailto:" + esc(email) + "\">" + esc(text) + "</a>");
+        htmlBuilder.append("<a href=\"mailto:" + email + "\">" + esc(text) + "</a>");
         return this;
     }
 
     public HTMLHelper addEmailLinkWithSize(String email, String text, int size) {
-        htmlBuilder.append("<span style=\"font-size:" + size + "px;\"> <a href=\"mailto:" + esc(email) + "\">" + esc(text) + "</a> </span>");
+        htmlBuilder.append("<span style=\"font-size:" + size + "px;\"> <a href=\"mailto:" + email + "\">" + esc(text) + "</a> </span>");
         return this;
     }
 

--- a/src/test/java/uk/ac/ebi/eva/submission/integration/SubmissionWSIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/submission/integration/SubmissionWSIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.transaction.TestTransaction;
@@ -48,6 +49,7 @@ import uk.ac.ebi.eva.submission.service.GlobusTokenRefreshService;
 import uk.ac.ebi.eva.submission.service.LoginMethod;
 import uk.ac.ebi.eva.submission.service.LsriTokenService;
 import uk.ac.ebi.eva.submission.service.WebinTokenService;
+import uk.ac.ebi.eva.submission.controller.authentication.BruteForceProtectionService;
 import uk.ac.ebi.eva.submission.util.EnaDownloader;
 
 import javax.persistence.EntityManager;
@@ -63,6 +65,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -144,13 +148,16 @@ public class SubmissionWSIntegrationTest {
     private String submissionId;
 
     @Container
-    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:9.6")
+    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:11")
             .withInitScript("init.sql");
     @Container
     static GenericContainer<?> mailhog = new GenericContainer<>(DockerImageName.parse("mailhog/mailhog"))
             .withExposedPorts(1025, 8025);
     @Autowired
     private SubmissionEloadRepository submissionEloadRepository;
+
+    @Autowired
+    private BruteForceProtectionService bruteForceProtectionService;
 
     @DynamicPropertySource
     static void dataSourceProperties(DynamicPropertyRegistry registry) {
@@ -176,6 +183,10 @@ public class SubmissionWSIntegrationTest {
 
         SubmissionAccount submissionAccount = new SubmissionAccount("eva", "webin", "eva", "eva", "eva@ebi.ac.uk");
         submissionAccountRepository.save(submissionAccount);
+
+        // Reset brute-force state between tests so they don't interfere with each other
+        ((Map<?, ?>) ReflectionTestUtils.getField(bruteForceProtectionService, "attempts")).clear();
+        ((Map<?, ?>) ReflectionTestUtils.getField(bruteForceProtectionService, "lockouts")).clear();
     }
 
     @Test
@@ -1870,6 +1881,34 @@ public class SubmissionWSIntegrationTest {
         }
     }
 
+
+    @Test
+    public void testAdminBruteForceProtection() throws Exception {
+        HttpHeaders badHeaders = new HttpHeaders();
+        badHeaders.setBasicAuth(TEST_ADMIN_USERNAME, "wrong-password");
+
+        // 10 failed attempts should not yet trigger lockout (each attempt returns 401)
+        for (int i = 0; i < 10; i++) {
+            mvc.perform(put("/v1/admin/submission/" + submissionId + "/status/COMPLETED")
+                            .headers(badHeaders)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        // 11th attempt should be blocked (429)
+        mvc.perform(put("/v1/admin/submission/" + submissionId + "/status/COMPLETED")
+                        .headers(badHeaders)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isTooManyRequests());
+
+        // Valid credentials are also blocked while IP is locked out
+        HttpHeaders goodHeaders = new HttpHeaders();
+        goodHeaders.setBasicAuth(TEST_ADMIN_USERNAME, TEST_ADMIN_PASSWORD);
+        mvc.perform(put("/v1/admin/submission/" + submissionId + "/status/COMPLETED")
+                        .headers(goodHeaders)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isTooManyRequests());
+    }
 
     private static List<String> getStringList(JsonNode node) {
         if (node.isArray()) {


### PR DESCRIPTION
1. HTML Injection in emails (HTMLHelper.java)
Added StringEscapeUtils.escapeHtml4() escaping to all 8 methods that append user-supplied strings into HTML email bodies, preventing injected markup from being rendered by mail clients.

2. Security config catch-all (SecurityConfiguration.java)
Added .anyRequest().authenticated() as the final rule. Without it, any URL not explicitly listed was unauthenticated by default — new endpoints added in future would be silently open.

3. BCrypt password encoding (SecurityConfiguration.java)
Replaced the {noop} plaintext password strategy with BCryptPasswordEncoder. The plain-text value in the property file is unchanged; only the in-memory representation is hashed.

4. Brute-force protection (BruteForceProtectionService.java + BruteForceProtectionFilter.java)
An event listener counts authentication failures per IP and locks out that IP for 15 minutes after 10 failures. A OncePerRequestFilter gates all /v1/admin/** routes, returning HTTP 429 to blocked IPs before the Basic auth filter
  runs.

5. Accession format validation (EnaDownloader.java, BioSamplesDownloader.java)
Added regex validation (^[A-Z]{1,6}[0-9]{1,9}$ and ^SAM[END][AG]?[0-9]+$) before using accession values to construct URLs, preventing path traversal or SSRF via crafted accession strings.

6. XXE hardening (EnaDownloader.java)
Disabled DOCTYPE declarations and external entity/parameter entity resolution on DocumentBuilderFactory before parsing ENA XML responses, blocking XML External Entity attacks.

7. Dependency updates (pom.xml, SubmissionWSIntegrationTest.java)
Spring Boot bumped from 2.7.10 to 2.7.18 (last 2.7.x release, picking up ~50 CVE fixes); the explicit spring-retry version pin removed so the Boot BOM manages it; Testcontainers PostgreSQL image updated from 9.6 to 11 to match production.

8. CustomBasicAuthenticationEntryPoint.java:39
Replaced authException.getMessage() with the fixed string "Authentication Failed" to prevent leaking internal auth details.

9. .github/workflows/run-tests.yml:
Added permissions: contents: read at the workflow level to restrict GITHUB_TOKEN to the minimum needed.